### PR TITLE
GPUs error handling

### DIFF
--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/desklet.js
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/desklet.js
@@ -106,7 +106,7 @@ SystemMonitorGraph.prototype = {
             this.ram_values  = new Array(2).fill(0.0);
             this.swap_values = new Array(2).fill(0.0);
             this.hdd_values  = new Array(4).fill(0.0);
-            this.gpu_use     = 0;
+            this.gpu_use     = NaN;
             this.gpu_mem     = new Array(2).fill(0.0);
 
             // set colors

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/desklet.js
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/desklet.js
@@ -514,10 +514,15 @@ SystemMonitorGraph.prototype = {
     },
 
     get_nvidia_gpu_use: function() {
-        let subprocess = Gio.Subprocess.new(
-            ['/usr/bin/nvidia-smi', '--query-gpu=utilization.gpu', '--format=csv', '--id='+ this.gpu_id],
-            Gio.SubprocessFlags.STDOUT_PIPE|Gio.SubprocessFlags.STDERR_PIPE
-        );
+        let subprocess
+        try {
+            subprocess = Gio.Subprocess.new(
+                ['/usr/bin/nvidia-smi', '--query-gpu=utilization.gpu', '--format=csv', '--id='+ this.gpu_id],
+                Gio.SubprocessFlags.STDOUT_PIPE|Gio.SubprocessFlags.STDERR_PIPE
+            );
+        } catch (err) {
+            return;
+        }
         subprocess.communicate_utf8_async(null, null, (subprocess, result) => {
             let [, stdout, stderr] = subprocess.communicate_utf8_finish(result);
             this.gpu_use =  parseInt(stdout.match(/[^\r\n]+/g)[1]); // parse integer in second line
@@ -525,10 +530,15 @@ SystemMonitorGraph.prototype = {
     },
 
     get_nvidia_gpu_mem: function() {
-        let subprocess = Gio.Subprocess.new(
-            ['/usr/bin/nvidia-smi', '--query-gpu=memory.total,memory.used', '--format=csv', '--id='+ this.gpu_id],
-            Gio.SubprocessFlags.STDOUT_PIPE|Gio.SubprocessFlags.STDERR_PIPE
-        );
+        let subprocess
+        try {
+            subprocess = Gio.Subprocess.new(
+                ['/usr/bin/nvidia-smi', '--query-gpu=memory.total,memory.used', '--format=csv', '--id='+ this.gpu_id],
+                Gio.SubprocessFlags.STDOUT_PIPE|Gio.SubprocessFlags.STDERR_PIPE
+            );
+        } catch {
+            return;
+        }
         subprocess.communicate_utf8_async(null, null, (subprocess, result) => {
             let [, stdout, stderr] = subprocess.communicate_utf8_finish(result);
             let fslines = stdout.split(/\r?\n/); // Line0:Headers Line1:Values

--- a/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/metadata.json
+++ b/system-monitor-graph@rcassani/files/system-monitor-graph@rcassani/metadata.json
@@ -3,6 +3,6 @@
     "uuid": "system-monitor-graph@rcassani",
     "name": "System monitor graph",
     "description": "Creates graphs for system variables.",
-    "version": "1.8",
+    "version": "1.9",
     "prevent-decorations": true
 }


### PR DESCRIPTION
Hi @Lazar-Kovacevic,

Thanks for the contribution for proper handling the readings and errors from AMD GPUs in this PR:
https://github.com/linuxmint/cinnamon-spices-desklets/pull/1407

I think, a similar approach is needed for NVIDIA GPUs so, it "breaks" peacefully. 

1. Now if GPU (NVIDIA or AMD) is not available the graph is shown but `NaN` is displayed
2. There is a test for the `nvidia-smi` command
3. Version update

This addition in the reason of being on the current PR. I tried to make it directly on your `master` branch, but of course I'm not allowed. 

Feel free to test and merge (if you think, it's ok) this PR in your master. So all the changes can go to the Linux Mint upstream. 